### PR TITLE
Added cstdint to fix error when compiling on Linux

### DIFF
--- a/includes/ColorCout.hpp
+++ b/includes/ColorCout.hpp
@@ -21,6 +21,7 @@ Copyright (C) 2020 GloomyGhost <GloomyGhost@foxmail.com>
 #define COLORBOX_COLORCOUT_H
 
 #include <iostream>
+#include <cstdint>
 
 #ifdef WIN32
 #ifndef WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
Building on linux appears to fail. Adding cstdint fixed the issue for me.

```
In file included from /home/berocs/git/openixcard/src/openixcard-1.1.8/src/OpenixCard/LOG.cpp:12:
/home/berocs/git/openixcard/src/openixcard-1.1.8/lib/ColorCout/includes/ColorCout.hpp:55:6: warning: elaborated-type-specifier for a scoped enum must not use the ‘class’ keyword
   55 | enum class cc : uint8_t {
      | ~~~~ ^~~~~
      |      -----
/home/berocs/git/openixcard/src/openixcard-1.1.8/lib/ColorCout/includes/ColorCout.hpp:55:15: error: found ‘:’ in nested-name-specifier, expected ‘::’
   55 | enum class cc : uint8_t {
      |               ^
      |               ::
/home/berocs/git/openixcard/src/openixcard-1.1.8/lib/ColorCout/includes/ColorCout.hpp:55:12: error: ‘cc’ has not been declared
   55 | enum class cc : uint8_t {
      |            ^~
/home/berocs/git/openixcard/src/openixcard-1.1.8/lib/ColorCout/includes/ColorCout.hpp:55:25: error: expected unqualified-id before ‘{’ token
   55 | enum class cc : uint8_t {
      |                         ^
/home/berocs/git/openixcard/src/openixcard-1.1.8/lib/ColorCout/includes/ColorCout.hpp:65:39: error: ‘cc’ does not name a type
   65 | type &operator<<(type &ostream, const cc color) {
      |                                       ^~
/home/berocs/git/openixcard/src/openixcard-1.1.8/lib/ColorCout/includes/ColorCout.hpp: In function ‘type& operator<<(type&, int)’:
/home/berocs/git/openixcard/src/openixcard-1.1.8/lib/ColorCout/includes/ColorCout.hpp:75:18: error: ‘cc’ has not been declared
   75 |     if (color == cc::reset) {
      |                  ^~
/home/berocs/git/openixcard/src/openixcard-1.1.8/lib/ColorCout/includes/ColorCout.hpp:96:43: error: ‘uint32_t’ does not name a type
   96 |         ostream << "\033[" << static_cast<uint32_t>(color) << "m";
      |                                           ^~~~~~~~
```